### PR TITLE
fix(husky): Add missing husky dependency and update prepare script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.2.6",
         "eslint-config-prettier": "^9.1.0",
+        "husky": "^9.1.5",
         "lint-staged": "^15.2.9",
         "postcss": "^8",
         "prettier": "3.3.3",
@@ -3612,6 +3613,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint-staged": "lint-staged",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "next": "14.2.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.6",
     "eslint-config-prettier": "^9.1.0",
+    "husky": "^9.1.5",
     "lint-staged": "^15.2.9",
     "postcss": "^8",
     "prettier": "3.3.3",


### PR DESCRIPTION
## Title: fix(husky): Add missing husky dependency and update prepare script

### What
- Added the missing `husky` dependency to `package.json`
- Updated the `prepare` script in `package.json` to use the new `husky` command instead of the deprecated `husky install`

### Why
The `husky` dependency was missing, which caused issues when trying to set up pre-commit hooks. Additionally, the previous `prepare` script was using the deprecated `husky install` command, which has been replaced by the simpler `husky` command in newer versions of the package.

### How
1. Added `"husky": "^9.1.5"` to the `devDependencies` in `package.json`
2. Updated the `prepare` script to `"prepare": "husky"` in `package.json`

### Checklist
- [x] Added `husky` to `package.json`
- [x] Updated `prepare` script
- [x] Tested that pre-commit hooks work correctly after the changes
