### PR TITLE
fix(husky): prevent Push to protected branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,17 @@
 #!/bin/bash
 protected_branches='main develop'
-current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
-for protected_branch in $protected_branches; do
-    if [ $protected_branch = $current_branch ]; then
-        echo "You're about to push protected branch ($(echo $protected_branch))."
-        exit 1 # push will not execute
-    fi
+
+# 커밋을 푸시하려는 대상에 대한 정보를 받아옴
+while read local_ref local_sha remote_ref remote_sha; do
+    # 원격 브랜치 이름 추출
+    branch_name=$(echo $remote_ref | sed 's/refs\/heads\///')
+
+    for protected_branch in $protected_branches; do
+        if [ $protected_branch = $branch_name ]; then
+            echo "You're about to push to a protected branch ($protected_branch). Push has been denied."
+            exit 1 # push will not execute
+        fi
+    done
 done
 
 exit 0 # push will execute

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -38,6 +38,7 @@ const Configuration: UserConfig = {
         "build", // Build scripts or configuration
         "ci", // Continuous integration
         "release", // Release related changes
+        "husky", // Husky related changes
         "other", // Other changes
       ],
     ],


### PR DESCRIPTION
### What
- Updated the `pre-push` script.
- Added `"husky"` to the `"scope-enum"` in `commitlint.config.ts` 

### Why
Previous code prevented Push by `local_ref`, not `remote_ref`. This wasn't able to prevent Push from `unprotected local branch` to `protected remote branch`, and this was not what we meant. Additionally add `"husky"` to the `"scope-enum"` in `commitlint.config.ts` for `husky` related changes.

### How
1. Updated the `pre-push` script, now it prevents Push by `remote_ref` not `local_ref`
2.. Added `"husky"` to the `"scope-enum"` in `commitlint.config.ts` 

### Checklist
- [x] Updated the `pre-push` script
- [x] Added `"husky"` to the `"scope-enum"`
- [x] Tested that pre-push hooks work correctly